### PR TITLE
Update changelog generation to compute new icons forward-looking

### DIFF
--- a/scripts/generate-changelog.ts
+++ b/scripts/generate-changelog.ts
@@ -124,11 +124,13 @@ function generateChangelog(): Changelog {
 
     for (let i = 0; i < versionsToProcess.length; i++) {
         const current = versionsToProcess[i];
-        const previous = versionsToProcess[i + 1];
+        // Look forward: from current version commit to next version commit (or HEAD for latest)
+        const next = i > 0 ? versionsToProcess[i - 1] : null;
 
+        // Get icons added AFTER this version commit up to the next version (or HEAD)
         const newIcons = getNewIconsBetweenCommits(
-            previous?.hash || '',
-            current.hash
+            current.hash,
+            next?.hash || 'HEAD'
         );
 
         console.log(`${current.version}: ${newIcons.length} new icons`);

--- a/src/changelog.html
+++ b/src/changelog.html
@@ -193,8 +193,62 @@ footer .footer-content {
         
             <details class="changelog-entry" open>
               <summary class="changelog-summary">
-                <span class="changelog-version">v1.6.6</span>
-                <span class="changelog-date">Oct 28, 2025</span>
+                <span class="changelog-version">v1.6.7</span>
+                <span class="changelog-date">Dec 24, 2025</span>
+                <span class="changelog-summary-rhs">
+                  <span class="changelog-count">10</span>
+                  <svg class="changelog-chevron" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m10 16 4-4-4-4"/></svg>
+                </span>
+              </summary>
+              <div class="changelog-content">
+                <div class="changelog-icons">
+            <button type="button" class="changelog-icon-btn downloadable-icon" data-icon-name="si_Eye" data-name="si_Eye" data-type="line" title="Eye">
+              <img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.7/Icons/Line/si_Eye.svg" width="20" height="20" alt="" loading="lazy" onerror="this.parentElement.style.display='none'" />
+            </button>
+          
+            <button type="button" class="changelog-icon-btn downloadable-icon" data-icon-name="si_Flow" data-name="si_Flow" data-type="line" title="Flow">
+              <img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.7/Icons/Line/si_Flow.svg" width="20" height="20" alt="" loading="lazy" onerror="this.parentElement.style.display='none'" />
+            </button>
+          
+            <button type="button" class="changelog-icon-btn downloadable-icon" data-icon-name="si_Flow_branch" data-name="si_Flow_branch" data-type="line" title="Flow_branch">
+              <img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.7/Icons/Line/si_Flow_branch.svg" width="20" height="20" alt="" loading="lazy" onerror="this.parentElement.style.display='none'" />
+            </button>
+          
+            <button type="button" class="changelog-icon-btn downloadable-icon" data-icon-name="si_Flow_cascade" data-name="si_Flow_cascade" data-type="line" title="Flow_cascade">
+              <img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.7/Icons/Line/si_Flow_cascade.svg" width="20" height="20" alt="" loading="lazy" onerror="this.parentElement.style.display='none'" />
+            </button>
+          
+            <button type="button" class="changelog-icon-btn downloadable-icon" data-icon-name="si_Flow_tree" data-name="si_Flow_tree" data-type="line" title="Flow_tree">
+              <img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.7/Icons/Line/si_Flow_tree.svg" width="20" height="20" alt="" loading="lazy" onerror="this.parentElement.style.display='none'" />
+            </button>
+          
+            <button type="button" class="changelog-icon-btn downloadable-icon" data-icon-name="si_Link" data-name="si_Link" data-type="line" title="Link">
+              <img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.7/Icons/Line/si_Link.svg" width="20" height="20" alt="" loading="lazy" onerror="this.parentElement.style.display='none'" />
+            </button>
+          
+            <button type="button" class="changelog-icon-btn downloadable-icon" data-icon-name="si_Nope" data-name="si_Nope" data-type="line" title="Nope">
+              <img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.7/Icons/Line/si_Nope.svg" width="20" height="20" alt="" loading="lazy" onerror="this.parentElement.style.display='none'" />
+            </button>
+          
+            <button type="button" class="changelog-icon-btn downloadable-icon" data-icon-name="si_Server" data-name="si_Server" data-type="line" title="Server">
+              <img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.7/Icons/Line/si_Server.svg" width="20" height="20" alt="" loading="lazy" onerror="this.parentElement.style.display='none'" />
+            </button>
+          
+            <button type="button" class="changelog-icon-btn downloadable-icon" data-icon-name="si_Umbrella" data-name="si_Umbrella" data-type="line" title="Umbrella">
+              <img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.7/Icons/Line/si_Umbrella.svg" width="20" height="20" alt="" loading="lazy" onerror="this.parentElement.style.display='none'" />
+            </button>
+          
+            <button type="button" class="changelog-icon-btn downloadable-icon" data-icon-name="si_Unlink" data-name="si_Unlink" data-type="line" title="Unlink">
+              <img src="https://cdn.jsdelivr.net/npm/sargam-icons@1.6.7/Icons/Line/si_Unlink.svg" width="20" height="20" alt="" loading="lazy" onerror="this.parentElement.style.display='none'" />
+            </button>
+          </div>
+              </div>
+            </details>
+          
+            <details class="changelog-entry" >
+              <summary class="changelog-summary">
+                <span class="changelog-version">v1.6.5</span>
+                <span class="changelog-date">Oct 23, 2025</span>
                 <span class="changelog-summary-rhs">
                   <span class="changelog-count">7</span>
                   <svg class="changelog-chevron" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m10 16 4-4-4-4"/></svg>
@@ -235,8 +289,8 @@ footer .footer-content {
           
             <details class="changelog-entry" >
               <summary class="changelog-summary">
-                <span class="changelog-version">v1.6.5</span>
-                <span class="changelog-date">Oct 23, 2025</span>
+                <span class="changelog-version">v1.6.4</span>
+                <span class="changelog-date">Oct 09, 2025</span>
                 <span class="changelog-summary-rhs">
                   <span class="changelog-count">7</span>
                   <svg class="changelog-chevron" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m10 16 4-4-4-4"/></svg>
@@ -277,8 +331,8 @@ footer .footer-content {
           
             <details class="changelog-entry" >
               <summary class="changelog-summary">
-                <span class="changelog-version">v1.6.4</span>
-                <span class="changelog-date">Oct 09, 2025</span>
+                <span class="changelog-version">v1.6.3</span>
+                <span class="changelog-date">Oct 08, 2025</span>
                 <span class="changelog-summary-rhs">
                   <span class="changelog-count">9</span>
                   <svg class="changelog-chevron" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m10 16 4-4-4-4"/></svg>
@@ -327,7 +381,7 @@ footer .footer-content {
           
             <details class="changelog-entry" >
               <summary class="changelog-summary">
-                <span class="changelog-version">v1.6.2</span>
+                <span class="changelog-version">v1.6.1</span>
                 <span class="changelog-date">Oct 06, 2025</span>
                 <span class="changelog-summary-rhs">
                   <span class="changelog-count">2</span>
@@ -349,8 +403,8 @@ footer .footer-content {
           
             <details class="changelog-entry" >
               <summary class="changelog-summary">
-                <span class="changelog-version">v1.6.1</span>
-                <span class="changelog-date">Oct 06, 2025</span>
+                <span class="changelog-version">v1.6.0</span>
+                <span class="changelog-date">Oct 03, 2025</span>
                 <span class="changelog-summary-rhs">
                   <span class="changelog-count">4</span>
                   <svg class="changelog-chevron" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m10 16 4-4-4-4"/></svg>
@@ -379,8 +433,8 @@ footer .footer-content {
           
             <details class="changelog-entry" >
               <summary class="changelog-summary">
-                <span class="changelog-version">v1.6.0</span>
-                <span class="changelog-date">Oct 03, 2025</span>
+                <span class="changelog-version">v1.5.1</span>
+                <span class="changelog-date">Oct 02, 2025</span>
                 <span class="changelog-summary-rhs">
                   <span class="changelog-count">27</span>
                   <svg class="changelog-chevron" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m10 16 4-4-4-4"/></svg>
@@ -501,8 +555,8 @@ footer .footer-content {
           
             <details class="changelog-entry" >
               <summary class="changelog-summary">
-                <span class="changelog-version">v1.5.1</span>
-                <span class="changelog-date">Oct 02, 2025</span>
+                <span class="changelog-version">v1.5.0</span>
+                <span class="changelog-date">Sep 29, 2025</span>
                 <span class="changelog-summary-rhs">
                   <span class="changelog-count">9</span>
                   <svg class="changelog-chevron" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m10 16 4-4-4-4"/></svg>
@@ -551,8 +605,8 @@ footer .footer-content {
           
             <details class="changelog-entry" >
               <summary class="changelog-summary">
-                <span class="changelog-version">v1.5.0</span>
-                <span class="changelog-date">Sep 29, 2025</span>
+                <span class="changelog-version">v1.4.12</span>
+                <span class="changelog-date">Sep 26, 2025</span>
                 <span class="changelog-summary-rhs">
                   <span class="changelog-count">20</span>
                   <svg class="changelog-chevron" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m10 16 4-4-4-4"/></svg>
@@ -645,8 +699,8 @@ footer .footer-content {
           
             <details class="changelog-entry" >
               <summary class="changelog-summary">
-                <span class="changelog-version">v1.4.12</span>
-                <span class="changelog-date">Sep 26, 2025</span>
+                <span class="changelog-version">v1.4.11</span>
+                <span class="changelog-date">Sep 25, 2025</span>
                 <span class="changelog-summary-rhs">
                   <span class="changelog-count">12</span>
                   <svg class="changelog-chevron" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m10 16 4-4-4-4"/></svg>
@@ -707,8 +761,8 @@ footer .footer-content {
           
             <details class="changelog-entry" >
               <summary class="changelog-summary">
-                <span class="changelog-version">v1.4.11</span>
-                <span class="changelog-date">Sep 25, 2025</span>
+                <span class="changelog-version">v1.3.0</span>
+                <span class="changelog-date">Dec 20, 2022</span>
                 <span class="changelog-summary-rhs">
                   <span class="changelog-count">61</span>
                   <svg class="changelog-chevron" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m10 16 4-4-4-4"/></svg>
@@ -965,8 +1019,8 @@ footer .footer-content {
           
             <details class="changelog-entry" >
               <summary class="changelog-summary">
-                <span class="changelog-version">v1.3.0</span>
-                <span class="changelog-date">Dec 20, 2022</span>
+                <span class="changelog-version">v1.0.1</span>
+                <span class="changelog-date">Oct 08, 2022</span>
                 <span class="changelog-summary-rhs">
                   <span class="changelog-count">37</span>
                   <svg class="changelog-chevron" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m10 16 4-4-4-4"/></svg>
@@ -1130,6 +1184,20 @@ footer .footer-content {
                 <span class="changelog-version">v1.0.0</span>
                 <span class="changelog-date">Oct 08, 2022</span>
                 <span class="changelog-summary-rhs">
+                  <span class="changelog-count">0</span>
+                  <svg class="changelog-chevron" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m10 16 4-4-4-4"/></svg>
+                </span>
+              </summary>
+              <div class="changelog-content">
+                <p class="changelog-empty">No new icons in this version</p>
+              </div>
+            </details>
+          
+            <details class="changelog-entry" >
+              <summary class="changelog-summary">
+                <span class="changelog-version">v0.7.0</span>
+                <span class="changelog-date">Oct 05, 2022</span>
+                <span class="changelog-summary-rhs">
                   <span class="changelog-count">10</span>
                   <svg class="changelog-chevron" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m10 16 4-4-4-4"/></svg>
                 </span>
@@ -1181,8 +1249,8 @@ footer .footer-content {
           
             <details class="changelog-entry" >
               <summary class="changelog-summary">
-                <span class="changelog-version">v0.7.0</span>
-                <span class="changelog-date">Oct 05, 2022</span>
+                <span class="changelog-version">v0.6.1</span>
+                <span class="changelog-date">Oct 02, 2022</span>
                 <span class="changelog-summary-rhs">
                   <span class="changelog-count">20</span>
                   <svg class="changelog-chevron" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m10 16 4-4-4-4"/></svg>
@@ -1275,8 +1343,8 @@ footer .footer-content {
           
             <details class="changelog-entry" >
               <summary class="changelog-summary">
-                <span class="changelog-version">v0.6.1</span>
-                <span class="changelog-date">Oct 02, 2022</span>
+                <span class="changelog-version">v0.6.0</span>
+                <span class="changelog-date">Oct 01, 2022</span>
                 <span class="changelog-summary-rhs">
                   <span class="changelog-count">11</span>
                   <svg class="changelog-chevron" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m10 16 4-4-4-4"/></svg>
@@ -1333,8 +1401,8 @@ footer .footer-content {
           
             <details class="changelog-entry" >
               <summary class="changelog-summary">
-                <span class="changelog-version">v0.6.0</span>
-                <span class="changelog-date">Oct 01, 2022</span>
+                <span class="changelog-version">v0.5.2</span>
+                <span class="changelog-date">Sep 24, 2022</span>
                 <span class="changelog-summary-rhs">
                   <span class="changelog-count">189</span>
                   <svg class="changelog-chevron" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24"><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m10 16 4-4-4-4"/></svg>

--- a/src/changelog.json
+++ b/src/changelog.json
@@ -1,10 +1,27 @@
 {
-  "generated": "2026-01-04T17:17:00.340Z",
+  "generated": "2026-01-04T17:29:45.714Z",
   "totalIcons": 433,
   "entries": [
     {
-      "version": "1.6.6",
-      "date": "2025-10-28",
+      "version": "1.6.7",
+      "date": "2025-12-24",
+      "newIcons": [
+        "Eye",
+        "Flow",
+        "Flow_branch",
+        "Flow_cascade",
+        "Flow_tree",
+        "Link",
+        "Nope",
+        "Server",
+        "Umbrella",
+        "Unlink"
+      ],
+      "highlights": []
+    },
+    {
+      "version": "1.6.5",
+      "date": "2025-10-23",
       "newIcons": [
         "AI_alt_2",
         "Activity",
@@ -17,8 +34,8 @@
       "highlights": []
     },
     {
-      "version": "1.6.5",
-      "date": "2025-10-23",
+      "version": "1.6.4",
+      "date": "2025-10-09",
       "newIcons": [
         "Bar_chart",
         "Barn",
@@ -31,8 +48,8 @@
       "highlights": []
     },
     {
-      "version": "1.6.4",
-      "date": "2025-10-09",
+      "version": "1.6.3",
+      "date": "2025-10-08",
       "newIcons": [
         "Crop",
         "Inflight",
@@ -47,7 +64,7 @@
       "highlights": []
     },
     {
-      "version": "1.6.2",
+      "version": "1.6.1",
       "date": "2025-10-06",
       "newIcons": [
         "AI_fact",
@@ -56,8 +73,8 @@
       "highlights": []
     },
     {
-      "version": "1.6.1",
-      "date": "2025-10-06",
+      "version": "1.6.0",
+      "date": "2025-10-03",
       "newIcons": [
         "Click",
         "Release_notes",
@@ -67,8 +84,8 @@
       "highlights": []
     },
     {
-      "version": "1.6.0",
-      "date": "2025-10-03",
+      "version": "1.5.1",
+      "date": "2025-10-02",
       "newIcons": [
         "AI",
         "AI_alt_1",
@@ -101,8 +118,8 @@
       "highlights": []
     },
     {
-      "version": "1.5.1",
-      "date": "2025-10-02",
+      "version": "1.5.0",
+      "date": "2025-09-29",
       "newIcons": [
         "Building",
         "Building_alt_1",
@@ -117,8 +134,8 @@
       "highlights": []
     },
     {
-      "version": "1.5.0",
-      "date": "2025-09-29",
+      "version": "1.4.12",
+      "date": "2025-09-26",
       "newIcons": [
         "Airplane",
         "Airplane_alt",
@@ -144,8 +161,8 @@
       "highlights": []
     },
     {
-      "version": "1.4.12",
-      "date": "2025-09-26",
+      "version": "1.4.11",
+      "date": "2025-09-25",
       "newIcons": [
         "Bin",
         "Map",
@@ -163,8 +180,8 @@
       "highlights": []
     },
     {
-      "version": "1.4.11",
-      "date": "2025-09-25",
+      "version": "1.3.0",
+      "date": "2022-12-20",
       "newIcons": [
         "Attachment",
         "Bluetooth",
@@ -231,8 +248,8 @@
       "highlights": []
     },
     {
-      "version": "1.3.0",
-      "date": "2022-12-20",
+      "version": "1.0.1",
+      "date": "2022-10-08",
       "newIcons": [
         "Actions",
         "Apple",
@@ -277,6 +294,12 @@
     {
       "version": "1.0.0",
       "date": "2022-10-08",
+      "newIcons": [],
+      "highlights": []
+    },
+    {
+      "version": "0.7.0",
+      "date": "2022-10-05",
       "newIcons": [
         "Home",
         "Home_detailed",
@@ -292,8 +315,8 @@
       "highlights": []
     },
     {
-      "version": "0.7.0",
-      "date": "2022-10-05",
+      "version": "0.6.1",
+      "date": "2022-10-02",
       "newIcons": [
         "Align_bottom_detailed",
         "Align_bottom_simple",
@@ -319,8 +342,8 @@
       "highlights": []
     },
     {
-      "version": "0.6.1",
-      "date": "2022-10-02",
+      "version": "0.6.0",
+      "date": "2022-10-01",
       "newIcons": [
         "Alert",
         "Bookmark",
@@ -337,8 +360,8 @@
       "highlights": []
     },
     {
-      "version": "0.6.0",
-      "date": "2022-10-01",
+      "version": "0.5.2",
+      "date": "2022-09-24",
       "newIcons": [
         "Add",
         "Add_alarm",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated changelog with new v1.6.7 release entry featuring expanded icon toolbar (eye, flow, flow_branch, flow_cascade, flow_tree, link, nope, server, umbrella, unlink).
  * Reorganized historical version entries in the changelog.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->